### PR TITLE
fix: address 7 Sonar security hotspots flagged on PR #29

### DIFF
--- a/forgelm/_http.py
+++ b/forgelm/_http.py
@@ -198,8 +198,12 @@ def safe_post(
     # Scheme policy.
     if parsed.scheme == "http":
         if not allow_insecure_http:
-            raise HttpSafetyError(  # NOSONAR — error string mentions "http://" by design (operator-facing rejection message)
-                f"http:// blocked (use https://); url={_mask_netloc(url)}"
+            # The rejection message intentionally names the blocked scheme so
+            # operators see WHY the call failed.  This is the security guard
+            # itself, not an insecure call site — Sonar S5332 is the inverse
+            # of the actual semantic.
+            raise HttpSafetyError(
+                f"http:// blocked (use https://); url={_mask_netloc(url)}"  # NOSONAR python:S5332 — operator-facing rejection message; this code BLOCKS the insecure scheme
             )
     elif parsed.scheme != "https":
         raise HttpSafetyError(f"Unsupported URL scheme {parsed.scheme!r}; only http(s) allowed.")

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -231,12 +231,18 @@ class TestSafePostHttpDiscipline:
             kwargs = mock_post.call_args.kwargs
             assert kwargs["allow_redirects"] is False
 
-    def test_http_block(self):
-        """http:// URLs are rejected unless allow_insecure_http is set."""
+    def test_http_block(
+        self,
+    ):  # NOSONAR python:S5332 — docstring describes the security guard; no insecure call is made
+        """Verify plain-HTTP URLs are rejected unless allow_insecure_http is set."""
         from forgelm._http import HttpSafetyError, safe_post
 
-        with pytest.raises(HttpSafetyError, match="http://"):
-            safe_post("http://example.com/hook", json={}, timeout=10.0)  # NOSONAR scheme blocker fixture
+        with pytest.raises(
+            HttpSafetyError, match="http://"
+        ):  # NOSONAR python:S5332 — match-regex literal, not an outbound call
+            safe_post(
+                "http://example.com/hook", json={}, timeout=10.0
+            )  # NOSONAR python:S5332 — scheme blocker fixture; verifies the guard rejects http://
 
     def test_http_allowed_with_opt_in(self):
         """allow_insecure_http=True (used by webhook) lets http:// through."""
@@ -252,13 +258,15 @@ class TestSafePostHttpDiscipline:
             )
             mock_post.assert_called_once()
 
-    def test_unsupported_scheme(self):
-        """ftp:// / file:// / etc. are rejected even with allow_insecure_http."""
+    def test_unsupported_scheme(
+        self,
+    ):  # NOSONAR python:S5332 — docstring names the rejected schemes; no insecure call is made
+        """Verify non-http(s) schemes (e.g., ftp, file) are rejected even with allow_insecure_http."""
         from forgelm._http import HttpSafetyError, safe_post
 
         with pytest.raises(HttpSafetyError, match="Unsupported URL scheme"):
             safe_post(
-                "ftp://example.com/hook",  # NOSONAR scheme blocker fixture (ftp not allowed)
+                "ftp://example.com/hook",  # NOSONAR python:S5332 — scheme blocker fixture; verifies the guard rejects ftp://
                 json={},
                 timeout=10.0,
                 allow_insecure_http=True,
@@ -416,7 +424,11 @@ class TestLifecycleVocabulary:
 
         notifier.notify_awaiting_approval(
             run_name="r",
-            model_path="/tmp/staged",
+            # Path string is sent as a webhook field; nothing is written to
+            # the filesystem in this test, so the publicly-writable-tmp
+            # concern (Sonar S5443) does not apply.  Use a project-relative
+            # placeholder shape to keep the test honest about that.
+            model_path="./outputs/run-r/final_model.staging",
         )
 
         call_kwargs = mock_post.call_args

--- a/tools/check_site_claims.py
+++ b/tools/check_site_claims.py
@@ -237,8 +237,10 @@ def site_template_names() -> set[str]:
     # Add any standalone slug that appears in the snippet body (e.g. the
     # bulleted list of templates in <pre>).
     for match in re.finditer(
-        r"^\s+([a-z][a-z0-9-]+-[a-z0-9-]+)\s{2,}", cleaned, flags=re.MULTILINE
-    ):  # NOSONAR — applied to controlled static HTML, not user input; ReDoS risk is not exploitable here
+        r"^\s+([a-z][a-z0-9-]+-[a-z0-9-]+)\s{2,}",  # NOSONAR python:S5852 — controlled static HTML input, not user-facing; ReDoS not exploitable
+        cleaned,
+        flags=re.MULTILINE,
+    ):
         found.add(match.group(1))
     return found
 


### PR DESCRIPTION
## Summary

Address all 7 Security Hotspots flagged by SonarCloud on PR #29
(`development → main` v0.5.5 consolidation), where the Quality
Gate is currently failing on **C Security Rating + 7 hotspots**.

After investigation each is a **verified false positive** — the
code is either the security guard itself, a test fixture
verifying the guard rejects insecure schemes, or a string argument
that is never written to disk. This PR corrects the in-code
documentation so a reviewer marking each hotspot as "Safe" in the
SonarCloud UI has the rationale on hand.

## Hotspot-by-hotspot disposition

| # | File:Line | Rule | Sev | Action |
|---|---|---|---|---|
| 1 | `tools/check_site_claims.py:240` | S5852 (regex DoS) | MEDIUM | NOSONAR moved onto regex literal line + rule tag |
| 2-3 | `forgelm/_http.py:202` | S5332 (http) | LOW × 2 | NOSONAR onto rejection f-string + rule tag + paragraph comment |
| 4 | `tests/test_webhook.py:235` | S5332 (http docstring) | LOW | Method-level NOSONAR + docstring rephrase |
| 5 | `tests/test_webhook.py:238` | S5332 (regex match) | LOW | NOSONAR onto `match=` line + rule tag |
| 6 | `tests/test_webhook.py:256` | S5332 (ftp docstring) | LOW | Method-level NOSONAR + docstring rephrase |
| 7 | `tests/test_webhook.py:419` | S5443 (publicly-writable dir) | LOW | `/tmp/staged` fixture replaced with `./outputs/run-r/final_model.staging` |

### Why each is a false positive

- **#1** runs against build-emitted static HTML (`controlled-input`
  per the existing NOSONAR comment); the polynomial-backtracking
  risk is unreachable.
- **#2-3** is the OPPOSITE of an insecure call — it's the
  `safe_post` guard's REJECTION f-string. Naming the blocked
  scheme is intentional so operators see WHY their call failed.
- **#4 + #6** flag http:// / ftp:// literals in docstrings of
  test methods that verify the guard rejects those schemes.
- **#5** is a `pytest.raises(match="http://")` regex pattern
  matching the error message, not an outbound call.
- **#7** is a string argument passed to a webhook payload — never
  written. Replaced with the project-relative shape that
  production code actually emits, which is also more faithful to
  what production `model_path` values look like.

## Self-review gauntlet (all green at HEAD `755b909`)

| Check | Result |
|---|---|
| `ruff format --check .` + `ruff check .` | ✅ clean |
| `check_bilingual_parity --strict` | ✅ 39/39 |
| `check_anchor_resolution --strict` | ✅ 264/264 |
| `check_cli_help_consistency --strict` | ✅ 425/425 |
| `check_site_claims --strict` | ✅ |
| `check_field_descriptions --strict` | ✅ |
| `pytest --no-cov -q tests/` | ✅ **1436 passed / 14 skipped** |
| `forgelm --config config_template.yaml --dry-run` | ✅ exit 0 |
| `tests/test_webhook.py` (targeted) | ✅ 32/32 |
| `tests/test_check_site_claims.py` (targeted) | ✅ 9/9 |

## Note for the SonarCloud review pass

Security Hotspots normally use SonarCloud's *"Mark as Safe"*
review workflow (not `# NOSONAR`, which is for issues). Even
after these in-code clarifications the maintainer may still need
to mark each of the 7 entries as Safe in the SonarCloud UI per
the standard hotspot-review process. The expanded in-code
comments make that UI review a 2-minute audit rather than a
re-derivation from scratch.

Once this PR merges to `development`, PR #29's Sonar quality gate
should re-scan and either drop the C rating to A (if NOSONAR is
honoured for hotspots in the configured Sonar setup) OR leave the
hotspots in TO_REVIEW state for the maintainer to mark Safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify and document SonarCloud security hotspots that are verified false positives so they can be reviewed and marked safe without altering runtime behavior.

Enhancements:
- Document the HTTP scheme rejection guard and regex usage with targeted NOSONAR annotations and clearer comments to explain why Sonar security rules do not apply.
- Rephrase webhook-related test docstrings and inline comments to describe security behavior without implying insecure outbound calls.
- Adjust a webhook test fixture path from a /tmp location to a project-relative model path shape to better reflect real payloads while avoiding public-temp-directory concerns.

Tests:
- Refine webhook tests to explicitly verify rejection of insecure or unsupported URL schemes while remaining compliant with SonarCloud hotspot analysis.