### PR TITLE
security: close DNS-rebinding TOCTOU in SSRF guard (closes #14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to ForgeLM are documented here.
 
 _(v0.6.1 dev cycle — entries will land here as PRs merge.)_
 
+### Security
+
+- **Webhook / judge / synthetic SSRF guard — DNS-rebinding TOCTOU
+  hardening (issue #14).** Pre-fix, `_is_private_destination()`
+  pre-resolved the hostname and `requests.post()` then ran its own
+  DNS lookup at connect time; an attacker-controlled DNS server with
+  TTL=0 could return a public IP on the first lookup (passing the
+  guard) and a private IP on the second (when `requests` connected),
+  leaking the payload + bearer token to a private destination
+  (loopback, RFC1918, or cloud IMDS at `169.254.169.254`). New
+  `_resolve_safe_destination()` helper resolves the hostname exactly
+  once and `safe_post` / `safe_get` rebuild the outbound URL with the
+  returned public IP literal so `requests` never re-resolves. The
+  original hostname is preserved via the `Host` header (and SNI for
+  HTTPS) using
+  `requests_toolbelt.adapters.host_header_ssl.HostHeaderSSLAdapter`
+  so virtual-hosted endpoints (Slack / Teams / Discord) and
+  certificate validation still work correctly. `allow_private=True`
+  callers (operator-blessed internal destinations) keep the legacy
+  flow so split-horizon DNS / in-cluster resolution still works.
+  `requests-toolbelt>=1.0.0,<2.0.0` is now a hard dependency.
+
 ## [0.6.0] — 2026-05-11
 
 Phase 15 (Ingestion Pipeline Reliability) Wave 1 + Wave 2. Closes the

--- a/forgelm/_http.py
+++ b/forgelm/_http.py
@@ -45,8 +45,8 @@ from __future__ import annotations
 import ipaddress
 import logging
 import socket
-from typing import Any, Dict, Optional
-from urllib.parse import urlparse
+from typing import Any, Dict, Optional, Tuple
+from urllib.parse import urlparse, urlunparse
 
 import requests
 
@@ -106,6 +106,133 @@ def _is_private_destination(host: str) -> bool:
         ):
             return True
     return False
+
+
+# ---------------------------------------------------------------------------
+# Issue #14 — DNS-rebinding-safe destination resolver
+# ---------------------------------------------------------------------------
+#
+# ``_is_private_destination`` above pre-resolves the host and answers a
+# yes/no question, but the actual ``requests.post`` call then does its OWN
+# DNS lookup at connect time.  Between those two lookups an attacker-
+# controlled DNS server can flip the answer (TTL=0 + rebinding to
+# 127.0.0.1 / 169.254.169.254), letting the payload + bearer token leak
+# to a private destination after passing the guard.  The resolver below
+# closes that window by returning a concrete public IP literal that the
+# call site uses to build the URL — requests then connects to that IP
+# without a second DNS round-trip.
+
+
+def _resolve_safe_destination(host: str) -> Tuple[Optional[str], Optional[str]]:
+    """Resolve *host* to a single public IP literal.
+
+    Returns ``(ip, None)`` when the host is a public destination, or
+    ``(None, reason)`` when the destination is blocked (private/loopback/
+    IMDS/multicast IP, empty host, or DNS resolution failure).
+
+    The caller substitutes the returned IP literal into the request URL
+    so ``requests`` does not re-resolve the hostname — this is the fix
+    for the DNS-rebinding TOCTOU described in issue #14.  The original
+    hostname must be propagated through the ``Host`` header (and SNI for
+    HTTPS) by the caller; this helper only owns the resolve+validate
+    step.
+
+    The picked IP is deterministic (first public address returned by
+    ``getaddrinfo``) so the test harness can mock the resolver without
+    flakiness.  When the host is already an IP literal, it is returned
+    as-is after the same private-range check.
+    """
+    if not host:
+        return None, "empty host"
+
+    # IP literal short-circuit — no DNS needed, same private-range filter.
+    try:
+        literal = ipaddress.ip_address(host)
+    except ValueError:
+        literal = None
+    if literal is not None:
+        if (
+            literal.is_private
+            or literal.is_loopback
+            or literal.is_link_local
+            or literal.is_reserved
+            or literal.is_multicast
+        ):
+            return None, "Private/loopback/IMDS destination"
+        return host, None
+
+    # Hostname path — one resolve, validate every returned address.  A
+    # mixed result (some public, some private) is treated as blocked
+    # because a follow-up connect could land on the private one.
+    try:
+        addrinfo = socket.getaddrinfo(host, None)
+    except (socket.gaierror, UnicodeError) as e:
+        return None, f"DNS resolution failed: {e}"
+
+    public_ip: Optional[str] = None
+    for _family, _type, _proto, _canon, sockaddr in addrinfo:
+        candidate = sockaddr[0]
+        try:
+            resolved = ipaddress.ip_address(candidate)
+        except ValueError:
+            continue
+        if (
+            resolved.is_private
+            or resolved.is_loopback
+            or resolved.is_link_local
+            or resolved.is_reserved
+            or resolved.is_multicast
+        ):
+            return None, "Private/loopback/IMDS destination"
+        if public_ip is None:
+            public_ip = candidate
+    if public_ip is None:
+        return None, "no public IP resolved"
+    return public_ip, None
+
+
+def _build_pinned_url(parsed_url, ip: str) -> str:
+    """Rebuild *parsed_url* with the hostname replaced by *ip*.
+
+    Preserves scheme, port, path, query, and fragment.  IPv6 literals
+    are bracketed per RFC 3986 (``https://[2001:db8::1]:443/path``).
+    Userinfo is intentionally dropped — webhook URLs may carry a token
+    in the path but never in userinfo, and stripping it removes one
+    avenue for accidental credential exposure in logs.
+    """
+    try:
+        is_ipv6 = ipaddress.ip_address(ip).version == 6
+    except ValueError:
+        is_ipv6 = False
+    netloc = f"[{ip}]" if is_ipv6 else ip
+    if parsed_url.port:
+        netloc = f"{netloc}:{parsed_url.port}"
+    return urlunparse(
+        (
+            parsed_url.scheme,
+            netloc,
+            parsed_url.path,
+            parsed_url.params,
+            parsed_url.query,
+            parsed_url.fragment,
+        )
+    )
+
+
+def _pinned_session(scheme: str) -> requests.Session:
+    """Return a ``requests.Session`` configured for IP-literal connections.
+
+    For HTTPS, mounts ``requests_toolbelt.adapters.host_header_ssl.
+    HostHeaderSSLAdapter`` so the SNI handshake and certificate
+    validation are performed against the original hostname (passed in
+    the ``Host`` header) rather than the IP literal in the URL.
+    """
+    session = requests.Session()
+    if scheme == "https":
+        from requests_toolbelt.adapters.host_header_ssl import HostHeaderSSLAdapter
+
+        session.mount("https://", HostHeaderSSLAdapter())
+    return session
 
 
 def _mask_netloc(url: str) -> str:
@@ -206,10 +333,23 @@ def safe_post(
     elif parsed.scheme != "https":
         raise HttpSafetyError(f"Unsupported URL scheme {parsed.scheme!r}; only http(s) allowed.")
 
-    # SSRF guard.
+    # SSRF guard — issue #14: resolve once to a public IP literal so the
+    # connect-time DNS lookup cannot flip the verdict (DNS rebinding /
+    # TOCTOU).  When ``allow_private=True`` the operator has explicitly
+    # opted into an internal/in-cluster destination; the legacy URL is
+    # used as-is so internal DNS / split-horizon resolution still works.
     host = parsed.hostname or ""
-    if not allow_private and _is_private_destination(host):
-        raise HttpSafetyError(f"Private/loopback/IMDS destination blocked: host={host or '<empty>'}")
+    target_url = url
+    request_headers: Dict[str, str] = dict(headers or {})
+    if not allow_private:
+        pinned_ip, block_reason = _resolve_safe_destination(host)
+        if block_reason:
+            raise HttpSafetyError(f"{block_reason} blocked: host={host or '<empty>'}")
+        target_url = _build_pinned_url(parsed, pinned_ip)
+        # ``Host`` is case-insensitive in HTTP/1.1; set it without
+        # overwriting an explicit operator override for testing/proxy
+        # scenarios.
+        request_headers.setdefault("Host", host)
 
     # Timeout floor — `requests` treats 0 / None as "no timeout" which can
     # hang the trainer on a dead endpoint.
@@ -220,18 +360,31 @@ def safe_post(
     verify_param: Any = ca_bundle if ca_bundle else verify
 
     try:
-        return requests.post(
-            url,
-            json=json,
-            data=data,
-            headers=headers,
-            timeout=timeout,
-            verify=verify_param,
-            # Redirect-following would bypass the up-front SSRF check —
-            # a 30x to 169.254.169.254 from an attacker-controlled host
-            # would otherwise leak the request payload to IMDS.
-            allow_redirects=False,
-        )
+        if allow_private:
+            # Legacy path: operator opted into a private destination;
+            # internal DNS / split-horizon resolution is the right model.
+            return requests.post(
+                url,
+                json=json,
+                data=data,
+                headers=request_headers,
+                timeout=timeout,
+                verify=verify_param,
+                # Redirect-following would bypass the up-front SSRF check —
+                # a 30x to 169.254.169.254 from an attacker-controlled host
+                # would otherwise leak the request payload to IMDS.
+                allow_redirects=False,
+            )
+        with _pinned_session(parsed.scheme) as session:
+            return session.post(
+                target_url,
+                json=json,
+                data=data,
+                headers=request_headers,
+                timeout=timeout,
+                verify=verify_param,
+                allow_redirects=False,
+            )
     except requests.RequestException as exc:
         masked_reason = _mask_secrets_in_text(str(exc), headers)
         logger.warning(
@@ -305,10 +458,16 @@ def safe_get(
     elif parsed.scheme != "https":
         raise HttpSafetyError(f"Unsupported URL scheme {parsed.scheme!r}; only http(s) allowed.")
 
-    # SSRF guard.
+    # SSRF guard — see safe_post for the issue-#14 DNS-rebinding rationale.
     host = parsed.hostname or ""
-    if not allow_private and _is_private_destination(host):
-        raise HttpSafetyError(f"Private/loopback/IMDS destination blocked: host={host or '<empty>'}")
+    target_url = url
+    request_headers: Dict[str, str] = dict(headers or {})
+    if not allow_private:
+        pinned_ip, block_reason = _resolve_safe_destination(host)
+        if block_reason:
+            raise HttpSafetyError(f"{block_reason} blocked: host={host or '<empty>'}")
+        target_url = _build_pinned_url(parsed, pinned_ip)
+        request_headers.setdefault("Host", host)
 
     # Timeout floor.
     if not isinstance(timeout, (int, float)) or timeout < min_timeout:
@@ -322,14 +481,24 @@ def safe_get(
     verify_param: Any = ca_bundle if ca_bundle else verify
 
     try:
-        return requests.request(
-            method_upper,
-            url,
-            headers=headers,
-            timeout=timeout,
-            verify=verify_param,
-            allow_redirects=False,
-        )
+        if allow_private:
+            return requests.request(
+                method_upper,
+                url,
+                headers=request_headers,
+                timeout=timeout,
+                verify=verify_param,
+                allow_redirects=False,
+            )
+        with _pinned_session(parsed.scheme) as session:
+            return session.request(
+                method_upper,
+                target_url,
+                headers=request_headers,
+                timeout=timeout,
+                verify=verify_param,
+                allow_redirects=False,
+            )
     except requests.RequestException as exc:
         masked_reason = _mask_secrets_in_text(str(exc), headers)
         logger.warning(

--- a/forgelm/_http.py
+++ b/forgelm/_http.py
@@ -45,10 +45,11 @@ from __future__ import annotations
 import ipaddress
 import logging
 import socket
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, MutableMapping, Optional, Tuple
 from urllib.parse import urlparse, urlunparse
 
 import requests
+from requests.structures import CaseInsensitiveDict
 
 logger = logging.getLogger("forgelm._http")
 
@@ -249,7 +250,7 @@ def _mask_netloc(url: str) -> str:
     return f"{parts.scheme}://{parts.hostname or 'unknown-host'}"
 
 
-def _mask_secrets_in_text(text: str, headers: Optional[Dict[str, str]]) -> str:
+def _mask_secrets_in_text(text: str, headers: Optional[MutableMapping[str, str]]) -> str:
     """Redact known secret-bearing header values from *text*.
 
     ``requests`` exception strings sometimes include the request URL or
@@ -338,21 +339,27 @@ def safe_post(
     # used as-is so internal DNS / split-horizon resolution still works.
     host = parsed.hostname or ""
     target_url = url
-    request_headers: Dict[str, str] = dict(headers or {})
+    # ``CaseInsensitiveDict`` so a caller-supplied ``host`` / ``HOST`` /
+    # ``Host`` all collapse to the same key — a plain ``dict`` would
+    # preserve the caller's casing and let ``setdefault("Host", ...)``
+    # silently add a *second* Host header to the request, producing a
+    # duplicate on the wire (RFC 7230 § 5.4 forbids this).
+    request_headers: MutableMapping[str, str] = CaseInsensitiveDict(headers or {})
     if not allow_private:
         pinned_ip, block_reason = _resolve_safe_destination(host)
         if block_reason:
             raise HttpSafetyError(f"{block_reason} blocked: host={host or '<empty>'}")
         target_url = _build_pinned_url(parsed, pinned_ip)
-        # ``Host`` is case-insensitive in HTTP/1.1; set it without
-        # overwriting an explicit operator override for testing/proxy
-        # scenarios.  Use ``netloc`` (with any userinfo stripped) rather
-        # than bare ``hostname`` so non-standard ports stay attached and
-        # IPv6 literals remain bracketed per RFC 7230 § 5.4 — bare
+        # ``Host`` is case-insensitive in HTTP/1.1; let an explicit
+        # caller override (any casing) win over the auto-derived value.
+        # Use ``netloc`` (with any userinfo stripped) rather than bare
+        # ``hostname`` so non-standard ports stay attached and IPv6
+        # literals remain bracketed per RFC 7230 § 5.4 — bare
         # ``hostname`` would emit ``Host: example.com`` for a request to
         # ``https://example.com:8443/`` and silently break virtual-hosted
         # endpoints that switch on the authority-form.
-        request_headers.setdefault("Host", parsed.netloc.rsplit("@", 1)[-1])
+        if "Host" not in request_headers:
+            request_headers["Host"] = parsed.netloc.rsplit("@", 1)[-1]
 
     # Timeout floor — `requests` treats 0 / None as "no timeout" which can
     # hang the trainer on a dead endpoint.
@@ -468,7 +475,9 @@ def safe_get(
     # SSRF guard — see safe_post for the issue-#14 DNS-rebinding rationale.
     host = parsed.hostname or ""
     target_url = url
-    request_headers: Dict[str, str] = dict(headers or {})
+    # CaseInsensitiveDict — see safe_post for the duplicate-Host-header
+    # rationale (caller may pass "host"/"HOST"/"Host" in any casing).
+    request_headers: MutableMapping[str, str] = CaseInsensitiveDict(headers or {})
     if not allow_private:
         pinned_ip, block_reason = _resolve_safe_destination(host)
         if block_reason:
@@ -476,8 +485,10 @@ def safe_get(
         target_url = _build_pinned_url(parsed, pinned_ip)
         # See safe_post: use netloc (sans userinfo) so non-standard
         # ports and IPv6 brackets survive into the Host header per
-        # RFC 7230 § 5.4.
-        request_headers.setdefault("Host", parsed.netloc.rsplit("@", 1)[-1])
+        # RFC 7230 § 5.4; case-insensitive containment honours an
+        # explicit caller override in any casing.
+        if "Host" not in request_headers:
+            request_headers["Host"] = parsed.netloc.rsplit("@", 1)[-1]
 
     # Timeout floor.
     if not isinstance(timeout, (int, float)) or timeout < min_timeout:

--- a/forgelm/_http.py
+++ b/forgelm/_http.py
@@ -65,6 +65,20 @@ class HttpSafetyError(Exception):
 _MASK_HEADER_NAMES = frozenset({"authorization", "x-api-key", "proxy-authorization"})
 
 
+def _is_blocked_ip(ip: ipaddress._BaseAddress) -> bool:
+    """Single source of truth for the SSRF private-range policy.
+
+    Encapsulates the set of address kinds that ForgeLM's SSRF guard
+    refuses to send outbound payloads to: RFC1918 private space, the
+    loopback range, link-local (incl. cloud IMDS at 169.254.169.254),
+    the IETF reserved buckets, and multicast.  Used by both
+    :func:`_is_private_destination` (legacy yes/no predicate) and
+    :func:`_resolve_safe_destination` (DNS-rebinding-safe resolver) so
+    the policy cannot drift between the two call sites.
+    """
+    return ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast
+
+
 def _is_private_destination(host: str) -> bool:
     """Return ``True`` when *host* resolves to a non-public-internet IP.
 
@@ -83,7 +97,7 @@ def _is_private_destination(host: str) -> bool:
     except ValueError:
         ip = None
     if ip is not None:
-        return ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast
+        return _is_blocked_ip(ip)
     try:
         addrinfo = socket.getaddrinfo(host, None)
     except (socket.gaierror, UnicodeError):
@@ -97,13 +111,7 @@ def _is_private_destination(host: str) -> bool:
             resolved = ipaddress.ip_address(sockaddr[0])
         except ValueError:
             continue
-        if (
-            resolved.is_private
-            or resolved.is_loopback
-            or resolved.is_link_local
-            or resolved.is_reserved
-            or resolved.is_multicast
-        ):
+        if _is_blocked_ip(resolved):
             return True
     return False
 
@@ -145,19 +153,15 @@ def _resolve_safe_destination(host: str) -> Tuple[Optional[str], Optional[str]]:
     if not host:
         return None, "empty host"
 
-    # IP literal short-circuit — no DNS needed, same private-range filter.
+    # IP literal short-circuit — no DNS needed, same private-range filter
+    # applied via the shared ``_is_blocked_ip`` helper so the IP-literal
+    # path and the DNS path cannot disagree.
     try:
         literal = ipaddress.ip_address(host)
     except ValueError:
         literal = None
     if literal is not None:
-        if (
-            literal.is_private
-            or literal.is_loopback
-            or literal.is_link_local
-            or literal.is_reserved
-            or literal.is_multicast
-        ):
+        if _is_blocked_ip(literal):
             return None, "Private/loopback/IMDS destination"
         return host, None
 
@@ -176,13 +180,7 @@ def _resolve_safe_destination(host: str) -> Tuple[Optional[str], Optional[str]]:
             resolved = ipaddress.ip_address(candidate)
         except ValueError:
             continue
-        if (
-            resolved.is_private
-            or resolved.is_loopback
-            or resolved.is_link_local
-            or resolved.is_reserved
-            or resolved.is_multicast
-        ):
+        if _is_blocked_ip(resolved):
             return None, "Private/loopback/IMDS destination"
         if public_ip is None:
             public_ip = candidate
@@ -348,8 +346,13 @@ def safe_post(
         target_url = _build_pinned_url(parsed, pinned_ip)
         # ``Host`` is case-insensitive in HTTP/1.1; set it without
         # overwriting an explicit operator override for testing/proxy
-        # scenarios.
-        request_headers.setdefault("Host", host)
+        # scenarios.  Use ``netloc`` (with any userinfo stripped) rather
+        # than bare ``hostname`` so non-standard ports stay attached and
+        # IPv6 literals remain bracketed per RFC 7230 § 5.4 — bare
+        # ``hostname`` would emit ``Host: example.com`` for a request to
+        # ``https://example.com:8443/`` and silently break virtual-hosted
+        # endpoints that switch on the authority-form.
+        request_headers.setdefault("Host", parsed.netloc.rsplit("@", 1)[-1])
 
     # Timeout floor — `requests` treats 0 / None as "no timeout" which can
     # hang the trainer on a dead endpoint.
@@ -386,7 +389,11 @@ def safe_post(
                 allow_redirects=False,
             )
     except requests.RequestException as exc:
-        masked_reason = _mask_secrets_in_text(str(exc), headers)
+        # Mask the *outbound* header set (which includes the auto-set
+        # ``Host`` and any caller secrets) — not the raw ``headers``
+        # parameter, which may be ``None`` or stale relative to what
+        # actually went on the wire.
+        masked_reason = _mask_secrets_in_text(str(exc), request_headers)
         logger.warning(
             "safe_post failed url=%s reason=%s",
             _mask_netloc(url),
@@ -467,7 +474,10 @@ def safe_get(
         if block_reason:
             raise HttpSafetyError(f"{block_reason} blocked: host={host or '<empty>'}")
         target_url = _build_pinned_url(parsed, pinned_ip)
-        request_headers.setdefault("Host", host)
+        # See safe_post: use netloc (sans userinfo) so non-standard
+        # ports and IPv6 brackets survive into the Host header per
+        # RFC 7230 § 5.4.
+        request_headers.setdefault("Host", parsed.netloc.rsplit("@", 1)[-1])
 
     # Timeout floor.
     if not isinstance(timeout, (int, float)) or timeout < min_timeout:
@@ -500,7 +510,9 @@ def safe_get(
                 allow_redirects=False,
             )
     except requests.RequestException as exc:
-        masked_reason = _mask_secrets_in_text(str(exc), headers)
+        # Mask the outbound header set, not the caller's possibly-None
+        # ``headers`` parameter — see safe_post for the same rationale.
+        masked_reason = _mask_secrets_in_text(str(exc), request_headers)
         logger.warning(
             "safe_get failed url=%s method=%s reason=%s",
             _mask_netloc(url),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,12 @@ dependencies = [
   "tensorboard>=2.15.0,<3.0.0",
   "huggingface_hub>=0.23.2,<1.0.0",
   "requests>=2.31.0,<3.0.0",
+  # requests-toolbelt is required by forgelm._http for the HostHeaderSSLAdapter
+  # used to close the DNS-rebinding TOCTOU window in safe_post / safe_get
+  # (issue #14). Small (~30KB) and from the same requests ecosystem, so it's
+  # a hard dep rather than an optional extra — SSRF hardening must always be
+  # active, not opt-in.
+  "requests-toolbelt>=1.0.0,<2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_http_dns_rebinding.py
+++ b/tests/test_http_dns_rebinding.py
@@ -174,9 +174,13 @@ class TestDnsRebindingClosed:
         not need the SSL adapter — no SNI involved."""
         from forgelm import _http
 
-        session = _http._pinned_session("http")
+        session = _http._pinned_session(
+            "http"
+        )  # NOSONAR python:S5332 — scheme fixture for the SSL-adapter dispatch branch; no outbound call.
         # Default HTTPAdapter, not HostHeaderSSLAdapter, on the http:// prefix.
-        adapter = session.get_adapter("http://example.com/")
+        adapter = session.get_adapter(
+            "http://example.com/"
+        )  # NOSONAR python:S5332 — adapter lookup fixture; no network egress.
         from requests_toolbelt.adapters.host_header_ssl import HostHeaderSSLAdapter
 
         assert not isinstance(adapter, HostHeaderSSLAdapter)
@@ -243,3 +247,144 @@ class TestSafeGetPinning:
         assert method == "GET"
         assert url == "https://8.8.8.8/api/models"
         assert headers["Host"] == "hub.example.com"
+
+    def test_safe_get_allow_private_bypasses_pinning(self):
+        """Mirror of safe_post's allow_private bypass for the read-side
+        helper — issue #14 review feedback (sourcery).  ``allow_private=True``
+        must keep the legacy ``requests.request`` flow (no Session, no
+        IP pinning) so internal DNS / split-horizon resolution still
+        resolves cluster-local registries.
+        """
+        from forgelm import _http
+
+        with (
+            patch.object(_http.socket, "getaddrinfo") as resolve_mock,
+            patch.object(_http.requests, "request") as legacy_request,
+            patch.object(_http.requests.Session, "request") as session_request,
+        ):
+            legacy_request.return_value = MagicMock(ok=True, status_code=200)
+            _http.safe_get(
+                "https://internal.registry.local/v1/models",
+                timeout=10.0,
+                allow_private=True,
+            )
+
+        resolve_mock.assert_not_called()
+        session_request.assert_not_called()
+        legacy_request.assert_called_once()
+
+
+class TestRfc7230HostHeader:
+    """Issue #14 review feedback (gemini): RFC 7230 § 5.4 requires the
+    ``Host`` header to match the request-target authority — including
+    non-standard ports and bracketed IPv6 literals.  Bare ``hostname``
+    drops both, so we use ``netloc`` (with any userinfo stripped)
+    instead.
+    """
+
+    def test_host_header_preserves_non_standard_port(self):
+        from forgelm import _http
+
+        with (
+            patch.object(_http.socket, "getaddrinfo", return_value=[(0, 0, 0, "", ("8.8.8.8", 0))]),
+            patch.object(_http.requests.Session, "post") as mock_post,
+        ):
+            mock_post.return_value = MagicMock(ok=True, status_code=200)
+            _http.safe_post("https://hooks.example.com:8443/abc", json={}, timeout=10.0)
+
+        headers = mock_post.call_args.kwargs["headers"]
+        assert headers["Host"] == "hooks.example.com:8443", (
+            f"Non-standard port must remain in the Host header per RFC 7230 § 5.4; got {headers['Host']!r}"
+        )
+
+    def test_host_header_brackets_ipv6_literal(self):
+        from forgelm import _http
+
+        # Hostname-resolved-to-IPv6 case is exercised by the URL builder
+        # test below; here we cover the IPv6-literal-in-URL form which
+        # the operator may supply when bypassing DNS entirely.
+        with patch.object(_http.requests.Session, "post") as mock_post:
+            mock_post.return_value = MagicMock(ok=True, status_code=200)
+            _http.safe_post("https://[2606:4700:4700::1111]/abc", json={}, timeout=10.0)
+
+        headers = mock_post.call_args.kwargs["headers"]
+        assert headers["Host"] == "[2606:4700:4700::1111]", (
+            f"IPv6 literal in Host header must stay bracketed per RFC 7230 § 5.4; got {headers['Host']!r}"
+        )
+
+    def test_host_header_strips_userinfo(self):
+        """If the URL carries ``user:pass@host`` userinfo, the Host
+        header must NOT echo it — that would leak the credential into
+        every outbound request, plus RFC 7230 § 5.4 explicitly forbids
+        userinfo in ``Host``.
+        """
+        from forgelm import _http
+
+        with (
+            patch.object(_http.socket, "getaddrinfo", return_value=[(0, 0, 0, "", ("8.8.8.8", 0))]),
+            patch.object(_http.requests.Session, "post") as mock_post,
+        ):
+            mock_post.return_value = MagicMock(ok=True, status_code=200)
+            _http.safe_post(
+                "https://user:pass@hooks.example.com/abc",  # noqa: S105 — userinfo fixture
+                json={},
+                timeout=10.0,
+            )
+
+        headers = mock_post.call_args.kwargs["headers"]
+        assert "@" not in headers["Host"]
+        assert headers["Host"] == "hooks.example.com"
+
+    def test_explicit_host_header_not_overridden(self):
+        """When the caller passes an explicit ``Host`` header (e.g. for
+        a reverse proxy / hostname-spoofing test setup), ``safe_post``
+        must respect it via ``setdefault`` and not overwrite — issue
+        #14 review feedback (sourcery).
+        """
+        from forgelm import _http
+
+        with (
+            patch.object(_http.socket, "getaddrinfo", return_value=[(0, 0, 0, "", ("8.8.8.8", 0))]),
+            patch.object(_http.requests.Session, "post") as mock_post,
+        ):
+            mock_post.return_value = MagicMock(ok=True, status_code=200)
+            _http.safe_post(
+                "https://hooks.example.com/abc",
+                json={},
+                headers={"Host": "operator-supplied.example.com"},
+                timeout=10.0,
+            )
+
+        headers = mock_post.call_args.kwargs["headers"]
+        assert headers["Host"] == "operator-supplied.example.com", (
+            "Caller's explicit Host header must take precedence over the auto-set value"
+        )
+
+
+class TestNoPublicIpResolvedBranch:
+    """Issue #14 review feedback (sourcery): cover the
+    ``"no public IP resolved"`` branch where ``getaddrinfo`` returns
+    only entries the resolver cannot parse as plain IP literals
+    (e.g. zone-id-suffixed IPv6 link-locals).
+    """
+
+    def test_only_unparseable_records_yields_no_public_ip(self):
+        from forgelm import _http
+
+        # All entries fail ``ipaddress.ip_address()`` — malformed IP
+        # strings of both v4 and v6 shape.  None of them is private
+        # (we never parse them) but none is public either, so the
+        # resolver must report "no public IP resolved" rather than
+        # silently letting an empty candidate set through.
+        with patch.object(
+            _http.socket,
+            "getaddrinfo",
+            return_value=[
+                (0, 0, 0, "", ("not-an-ip", 0)),
+                (0, 0, 0, "", ("999.999.999.999", 0)),
+            ],
+        ):
+            ip, err = _http._resolve_safe_destination("weird.example.com")
+
+        assert ip is None
+        assert err == "no public IP resolved"

--- a/tests/test_http_dns_rebinding.py
+++ b/tests/test_http_dns_rebinding.py
@@ -1,0 +1,245 @@
+"""Issue #14 regression tests — DNS-rebinding TOCTOU hardening for the
+webhook / judge / synthetic SSRF guard.
+
+Pre-fix: ``_is_private_destination()`` ran a DNS lookup, then
+``requests.post()`` ran ANOTHER DNS lookup at connect time.  An
+attacker-controlled DNS server with TTL=0 could return a public IP on
+the first lookup (passing the guard) and a private IP on the second
+(when ``requests`` connected), leaking the payload + bearer token to a
+private destination.
+
+Post-fix: ``_resolve_safe_destination()`` resolves the hostname once and
+the call site reuses the returned IP literal in the URL.  The original
+hostname is propagated via the ``Host`` header and (for HTTPS) the SNI
+extension of ``requests_toolbelt.adapters.host_header_ssl.
+HostHeaderSSLAdapter``, so virtual-hosting endpoints and certificate
+validation still work.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestResolveSafeDestination:
+    """Unit-level coverage of the resolver helper."""
+
+    def test_public_hostname_returns_first_public_ip(self):
+        from forgelm import _http
+
+        # Two public-A addrinfo entries.
+        with patch.object(
+            _http.socket,
+            "getaddrinfo",
+            return_value=[
+                (0, 0, 0, "", ("8.8.8.8", 0)),
+                (0, 0, 0, "", ("8.8.4.4", 0)),
+            ],
+        ):
+            ip, err = _http._resolve_safe_destination("hooks.example.com")
+        assert err is None
+        assert ip == "8.8.8.8"
+
+    def test_private_ip_in_resolution_blocks(self):
+        """Even one private answer in addrinfo flips the verdict to blocked."""
+        from forgelm import _http
+
+        with patch.object(
+            _http.socket,
+            "getaddrinfo",
+            return_value=[
+                (0, 0, 0, "", ("8.8.8.8", 0)),
+                (0, 0, 0, "", ("10.0.0.1", 0)),  # NOSONAR RFC1918 — guard fixture
+            ],
+        ):
+            ip, err = _http._resolve_safe_destination("attacker.example.com")
+        assert ip is None
+        assert "Private" in err and "IMDS" in err
+
+    def test_dns_failure_blocks_with_reason(self):
+        from forgelm import _http
+
+        with patch.object(_http.socket, "getaddrinfo", side_effect=_http.socket.gaierror("nodename")):
+            ip, err = _http._resolve_safe_destination("no-such.example.com")
+        assert ip is None
+        assert err.startswith("DNS resolution failed")
+
+    def test_empty_host_blocks(self):
+        from forgelm._http import _resolve_safe_destination
+
+        ip, err = _resolve_safe_destination("")
+        assert ip is None
+        assert err == "empty host"
+
+    def test_public_ip_literal_passes_through(self):
+        from forgelm._http import _resolve_safe_destination
+
+        ip, err = _resolve_safe_destination("8.8.8.8")
+        assert err is None
+        assert ip == "8.8.8.8"
+
+    def test_private_ip_literal_blocks(self):
+        from forgelm._http import _resolve_safe_destination
+
+        ip, err = _resolve_safe_destination("169.254.169.254")  # NOSONAR AWS IMDS — guard fixture
+        assert ip is None
+        assert "Private" in err
+
+
+class TestDnsRebindingClosed:
+    """Behavioural test: a TOCTOU-style rebinding cannot leak the payload.
+
+    Simulates a DNS server that returns a public IP on the first lookup
+    (the guard's call) and a private IP on a hypothetical second lookup
+    (what the old code path would have invoked from inside requests).
+    The hardened path must call ``getaddrinfo`` exactly once and pin the
+    public IP into the outbound URL.
+    """
+
+    def test_getaddrinfo_called_exactly_once_and_pins_public_ip(self):
+        from forgelm import _http
+
+        # First call: public. If the code ever called a second time
+        # (the TOCTOU window), it would get the IMDS address.  The
+        # assertion below asserts the second call never happens.
+        responses = iter(
+            [
+                [(0, 0, 0, "", ("8.8.8.8", 0))],  # 1st call — public
+                [(0, 0, 0, "", ("169.254.169.254", 0))],  # 2nd call — would be IMDS  # NOSONAR
+            ]
+        )
+
+        def fake_resolve(*_args, **_kwargs):
+            try:
+                return next(responses)
+            except StopIteration:
+                pytest.fail("getaddrinfo called more than once — DNS rebinding window is still open")
+
+        with (
+            patch.object(_http.socket, "getaddrinfo", side_effect=fake_resolve) as resolve_mock,
+            patch.object(_http.requests.Session, "post") as mock_post,
+        ):
+            mock_post.return_value = MagicMock(ok=True, status_code=200)
+            _http.safe_post("https://hooks.example.com/abc", json={}, timeout=10.0)
+
+        assert resolve_mock.call_count == 1, (
+            f"DNS rebinding fix requires exactly one resolve per safe_post call, got {resolve_mock.call_count}"
+        )
+        # The URL handed to Session.post must be the IP literal, not the hostname.
+        called_url = mock_post.call_args.args[0] if mock_post.call_args.args else mock_post.call_args.kwargs.get("url")
+        assert called_url == "https://8.8.8.8/abc", (
+            f"safe_post must rebuild the URL with the resolved public IP literal; got {called_url!r}"
+        )
+
+    def test_host_header_preserved_after_ip_pin(self):
+        """The original hostname must travel via ``Host`` header so the
+        upstream virtual host receives the right request line."""
+        from forgelm import _http
+
+        with (
+            patch.object(_http.socket, "getaddrinfo", return_value=[(0, 0, 0, "", ("8.8.8.8", 0))]),
+            patch.object(_http.requests.Session, "post") as mock_post,
+        ):
+            mock_post.return_value = MagicMock(ok=True, status_code=200)
+            _http.safe_post(
+                "https://hooks.example.com/abc",
+                json={},
+                headers={"Authorization": "Bearer secret"},  # noqa: S105 — test fixture
+                timeout=10.0,
+            )
+
+        headers = mock_post.call_args.kwargs["headers"]
+        assert headers["Host"] == "hooks.example.com"
+        # The opt-in auth header must be preserved alongside Host.
+        assert headers["Authorization"] == "Bearer secret"
+
+    def test_https_uses_host_header_ssl_adapter(self):
+        """For HTTPS the Session must mount HostHeaderSSLAdapter so SNI
+        and cert validation are performed against the original hostname,
+        not the IP literal in the URL."""
+        from forgelm import _http
+
+        with patch.object(_http.socket, "getaddrinfo", return_value=[(0, 0, 0, "", ("8.8.8.8", 0))]):
+            session = _http._pinned_session("https")
+        # Ensure an https://-mounted adapter exists and is the HostHeaderSSLAdapter.
+        adapter = session.get_adapter("https://example.com/")
+        from requests_toolbelt.adapters.host_header_ssl import HostHeaderSSLAdapter
+
+        assert isinstance(adapter, HostHeaderSSLAdapter)
+
+    def test_http_session_does_not_mount_ssl_adapter(self):
+        """The HTTP branch (operator opt-in via allow_insecure_http) must
+        not need the SSL adapter — no SNI involved."""
+        from forgelm import _http
+
+        session = _http._pinned_session("http")
+        # Default HTTPAdapter, not HostHeaderSSLAdapter, on the http:// prefix.
+        adapter = session.get_adapter("http://example.com/")
+        from requests_toolbelt.adapters.host_header_ssl import HostHeaderSSLAdapter
+
+        assert not isinstance(adapter, HostHeaderSSLAdapter)
+
+    def test_allow_private_bypasses_pinning(self):
+        """``allow_private=True`` is the documented in-cluster/internal
+        destination opt-in; the legacy ``requests.post`` flow runs so
+        internal DNS / split-horizon resolution still works."""
+        from forgelm import _http
+
+        with (
+            patch.object(_http.socket, "getaddrinfo") as resolve_mock,
+            patch.object(_http.requests, "post") as mock_post,
+            patch.object(_http.requests.Session, "post") as session_post_mock,
+        ):
+            mock_post.return_value = MagicMock(ok=True, status_code=200)
+            _http.safe_post(
+                "https://internal.corp.local/hook",
+                json={},
+                timeout=10.0,
+                allow_private=True,
+            )
+
+        resolve_mock.assert_not_called()  # No DNS pre-resolve in the opt-in path
+        session_post_mock.assert_not_called()  # No Session.post either
+        mock_post.assert_called_once()  # Legacy requests.post path
+
+
+class TestIpv6PinningBuildsBracketedUrl:
+    """IPv6 IP literals must be bracketed in the rebuilt URL per RFC 3986."""
+
+    def test_ipv6_url_is_bracketed(self):
+        from forgelm import _http
+
+        with (
+            patch.object(_http.socket, "getaddrinfo", return_value=[(0, 0, 0, "", ("2606:4700:4700::1111", 0))]),
+            patch.object(_http.requests.Session, "post") as mock_post,
+        ):
+            mock_post.return_value = MagicMock(ok=True, status_code=200)
+            _http.safe_post("https://v6.example.com/abc", json={}, timeout=10.0)
+
+        called_url = mock_post.call_args.args[0]
+        assert called_url == "https://[2606:4700:4700::1111]/abc"
+
+
+class TestSafeGetPinning:
+    """``safe_get`` mirrors ``safe_post`` for the same hardening contract."""
+
+    def test_safe_get_pins_url_and_sets_host_header(self):
+        from forgelm import _http
+
+        with (
+            patch.object(_http.socket, "getaddrinfo", return_value=[(0, 0, 0, "", ("8.8.8.8", 0))]),
+            patch.object(_http.requests.Session, "request") as mock_request,
+        ):
+            mock_request.return_value = MagicMock(ok=True, status_code=200)
+            _http.safe_get("https://hub.example.com/api/models", timeout=10.0)
+
+        # Session.request("GET", url, ...)
+        method = mock_request.call_args.args[0]
+        url = mock_request.call_args.args[1]
+        headers = mock_request.call_args.kwargs["headers"]
+
+        assert method == "GET"
+        assert url == "https://8.8.8.8/api/models"
+        assert headers["Host"] == "hub.example.com"

--- a/tests/test_http_dns_rebinding.py
+++ b/tests/test_http_dns_rebinding.py
@@ -360,6 +360,42 @@ class TestRfc7230HostHeader:
             "Caller's explicit Host header must take precedence over the auto-set value"
         )
 
+    def test_caller_host_header_with_different_casing_does_not_duplicate(self):
+        """Mixed-casing caller header (e.g. ``{"host": ...}``) must not
+        produce two Host entries on the wire.  Issue #14 review-round-2
+        (codex): a plain ``dict(headers or {})`` preserves the caller's
+        casing, so ``setdefault("Host", ...)`` would silently add a
+        second header alongside the caller's ``"host"`` key — invalid
+        per RFC 7230 § 5.4 and a wire-format ambiguity (``requests``
+        dedupes via its own ``CaseInsensitiveDict`` but the outbound
+        argument we send must already be single-valued so we can
+        observe it in this test).
+        """
+        from forgelm import _http
+
+        with (
+            patch.object(_http.socket, "getaddrinfo", return_value=[(0, 0, 0, "", ("8.8.8.8", 0))]),
+            patch.object(_http.requests.Session, "post") as mock_post,
+        ):
+            mock_post.return_value = MagicMock(ok=True, status_code=200)
+            _http.safe_post(
+                "https://hooks.example.com/abc",
+                json={},
+                # NB: lowercase ``host``.  A naive ``dict`` would let
+                # ``setdefault("Host", auto_value)`` add a second header
+                # because dict keys are case-sensitive.
+                headers={"host": "operator-supplied.example.com"},
+                timeout=10.0,
+            )
+
+        headers = mock_post.call_args.kwargs["headers"]
+        # Exactly one Host entry — case-insensitively — must exist.
+        host_keys = [k for k in headers.keys() if k.lower() == "host"]
+        assert len(host_keys) == 1, f"Expected exactly one Host header, got {host_keys}"
+        # The caller's explicit value must win.
+        assert headers["Host"] == "operator-supplied.example.com"
+        assert headers["host"] == "operator-supplied.example.com"
+
 
 class TestNoPublicIpResolvedBranch:
     """Issue #14 review feedback (sourcery): cover the

--- a/tests/test_judge_functions.py
+++ b/tests/test_judge_functions.py
@@ -57,7 +57,7 @@ class TestParseJudgeJson:
 
 
 class TestCallApiJudge:
-    @patch("forgelm._http.requests.post")
+    @patch("forgelm._http.requests.Session.post")
     def test_successful_api_call(self, mock_post):
         mock_response = MagicMock()
         mock_response.json.return_value = {"choices": [{"message": {"content": '{"score": 8, "reason": "Good"}'}}]}
@@ -70,7 +70,7 @@ class TestCallApiJudge:
         assert result["score"] == 8
         mock_post.assert_called_once()
 
-    @patch("forgelm._http.requests.post")
+    @patch("forgelm._http.requests.Session.post")
     def test_api_timeout(self, mock_post):
         import requests
 
@@ -83,8 +83,17 @@ class TestCallApiJudge:
         assert result["score"] is None
         assert "API error" in result["reason"]
 
-    @patch("forgelm._http.requests.post")
-    def test_custom_api_base(self, mock_post):
+    @patch("forgelm._http._resolve_safe_destination", return_value=("8.8.8.8", None))
+    @patch("forgelm._http.requests.Session.post")
+    def test_custom_api_base(self, mock_post, _mock_resolve):
+        """``api_base`` override drives the request to ``custom.api``.
+
+        Post-issue-#14 the URL passed to ``Session.post`` is rebuilt with
+        the resolved IP literal, so we assert on the ``Host`` header (which
+        carries the original hostname) instead of the URL string itself.
+        DNS is mocked so the test does not require live resolution of
+        the synthetic ``custom.api`` fixture domain.
+        """
         mock_response = MagicMock()
         mock_response.json.return_value = {"choices": [{"message": {"content": '{"score": 7, "reason": "OK"}'}}]}
         mock_response.raise_for_status = MagicMock()
@@ -94,7 +103,10 @@ class TestCallApiJudge:
 
         _call_api_judge("prompt", "key", "model", api_base="https://custom.api/v1/chat")
         call_args = mock_post.call_args
-        assert call_args[0][0] == "https://custom.api/v1/chat"
+        headers = call_args.kwargs.get("headers") or {}
+        assert headers.get("Host") == "custom.api", (
+            f"Host header should reflect the custom api_base hostname; got {headers!r}"
+        )
 
 
 class TestJudgeResult:
@@ -108,7 +120,7 @@ class TestJudgeResult:
 
 @pytest.mark.skipif(not torch_available, reason="torch not installed")
 class TestJudgeScoreClipping:
-    @patch("forgelm._http.requests.post")
+    @patch("forgelm._http.requests.Session.post")
     def test_score_above_10_clipped_to_10(self, mock_post, caplog):
         """Scores above 10 must be clamped to 10.0 with a warning."""
         import logging
@@ -129,7 +141,7 @@ class TestJudgeScoreClipping:
         # _call_api_judge returns the raw parsed value.
         assert result["score"] == 15
 
-    @patch("forgelm._http.requests.post")
+    @patch("forgelm._http.requests.Session.post")
     def test_score_clipped_in_run_judge_evaluation(self, mock_post, tmp_path, caplog):
         """run_judge_evaluation must clip out-of-range scores and emit a warning."""
         import logging
@@ -177,7 +189,7 @@ class TestJudgeScoreClipping:
         # Warning must be emitted
         assert any("clipped" in r.message or "out-of-range" in r.message for r in caplog.records)
 
-    @patch("forgelm._http.requests.post")
+    @patch("forgelm._http.requests.Session.post")
     def test_score_below_1_clipped_to_1(self, mock_post, tmp_path):
         """Scores below 1 must be clamped to 1.0."""
         import torch
@@ -215,9 +227,16 @@ class TestJudgeScoreClipping:
 
 
 class TestJudgeApiBasePassthrough:
-    @patch("forgelm._http.requests.post")
-    def test_api_base_reaches_http_call(self, mock_post):
-        """judge_api_base in config must be forwarded to the HTTP POST call."""
+    @patch("forgelm._http._resolve_safe_destination", return_value=("8.8.8.8", None))
+    @patch("forgelm._http.requests.Session.post")
+    def test_api_base_reaches_http_call(self, mock_post, _mock_resolve):
+        """``judge_api_base`` must be forwarded to the HTTP POST.
+
+        Asserts via the ``Host`` header because issue-#14 hardening rebuilds
+        the URL with the resolved IP literal before the actual call —
+        carrying the original hostname over to the request via the
+        ``Host`` header (and SNI for HTTPS).
+        """
         mock_response = MagicMock()
         mock_response.json.return_value = {"choices": [{"message": {"content": '{"score": 7, "reason": "OK"}'}}]}
         mock_response.raise_for_status = MagicMock()
@@ -229,9 +248,10 @@ class TestJudgeApiBasePassthrough:
         _call_api_judge("prompt", "key", "model", api_base=custom_base)
 
         call_args = mock_post.call_args
-        actual_url = call_args[0][0] if call_args[0] else call_args.kwargs.get("url") or call_args[1].get("url")
-        # The URL passed to requests.post should match the custom api_base
-        assert actual_url == custom_base
+        headers = call_args.kwargs.get("headers") or {}
+        assert headers.get("Host") == "custom.llm.api", (
+            f"Host header should reflect the custom judge_api_base hostname; got {headers!r}"
+        )
 
 
 class TestJudgeUsesSafePost:
@@ -252,7 +272,7 @@ class TestJudgeUsesSafePost:
         src = inspect.getsource(judge._call_api_judge)
         assert "safe_post" in src, "judge._call_api_judge must use safe_post"
 
-    @patch("forgelm._http.requests.post")
+    @patch("forgelm._http.requests.Session.post")
     def test_judge_call_goes_through_safe_post(self, mock_post):
         """A successful judge call must hit requests.post (via safe_post)."""
         mock_response = MagicMock()
@@ -271,7 +291,7 @@ class TestJudgeUsesSafePost:
         assert kwargs.get("allow_redirects") is False
         assert result["score"] == 7
 
-    @patch("forgelm._http.requests.post")
+    @patch("forgelm._http.requests.Session.post")
     def test_judge_ssrf_block_for_private_url(self, mock_post):
         """A private-IP api_base must be rejected before any network call.
 

--- a/tests/test_synthetic.py
+++ b/tests/test_synthetic.py
@@ -285,7 +285,7 @@ class TestSyntheticUsesSafePost:
         src = inspect.getsource(synthetic.SyntheticDataGenerator._call_api_teacher)
         assert "safe_post" in src, "synthetic._call_api_teacher must use safe_post"
 
-    @patch("forgelm._http.requests.post")
+    @patch("forgelm._http.requests.Session.post")
     def test_synthetic_call_goes_through_safe_post(self, mock_post):
         """A successful API teacher call routes through safe_post → requests.post."""
         mock_response = MagicMock()
@@ -313,7 +313,7 @@ class TestSyntheticUsesSafePost:
         # safe_post forwards allow_redirects=False
         assert kwargs.get("allow_redirects") is False
 
-    @patch("forgelm._http.requests.post")
+    @patch("forgelm._http.requests.Session.post")
     def test_synthetic_ssrf_block_for_private_api_base(self, mock_post):
         """A private-IP api_base must be rejected before any network call."""
         from forgelm._http import HttpSafetyError

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -39,7 +39,7 @@ class TestWebhookNotifier:
         notifier = WebhookNotifier(config)
         notifier.notify_start(run_name="test")
 
-    @patch("forgelm._http.requests.post")
+    @patch("forgelm._http.requests.Session.post")
     def test_notify_start(self, mock_post):
         config = _make_config({"url": "https://example.com/hook"})
         notifier = WebhookNotifier(config)
@@ -52,7 +52,7 @@ class TestWebhookNotifier:
         assert payload["status"] == "started"
         assert payload["run_name"] == "my_model_finetune"
 
-    @patch("forgelm._http.requests.post")
+    @patch("forgelm._http.requests.Session.post")
     def test_notify_success_with_metrics(self, mock_post):
         config = _make_config({"url": "https://example.com/hook"})
         notifier = WebhookNotifier(config)
@@ -64,7 +64,7 @@ class TestWebhookNotifier:
         assert payload["event"] == "training.success"
         assert payload["metrics"]["eval_loss"] == pytest.approx(1.25)
 
-    @patch("forgelm._http.requests.post")
+    @patch("forgelm._http.requests.Session.post")
     def test_notify_failure_with_reason(self, mock_post):
         config = _make_config({"url": "https://example.com/hook"})
         notifier = WebhookNotifier(config)
@@ -75,8 +75,17 @@ class TestWebhookNotifier:
         assert payload["event"] == "training.failure"
         assert payload["reason"] == "OOM error"
 
-    @patch("forgelm._http.requests.post")
-    def test_url_env_resolution(self, mock_post):
+    @patch("forgelm._http._resolve_safe_destination", return_value=("8.8.8.8", None))
+    @patch("forgelm._http.requests.Session.post")
+    def test_url_env_resolution(self, mock_post, _mock_resolve):
+        """``url_env`` resolution must drive the request to env.example.com.
+
+        Post-issue-#14 the URL passed to ``Session.post`` is rebuilt with the
+        resolved IP literal, so we assert via the ``Host`` header (which
+        carries the original hostname) instead of the URL itself.  DNS is
+        mocked because ``env.example.com`` does not resolve in real life
+        (IANA only publishes A records for ``example.com`` itself).
+        """
         config = _make_config({"url_env": "TEST_WEBHOOK_URL"})
         notifier = WebhookNotifier(config)
 
@@ -85,12 +94,12 @@ class TestWebhookNotifier:
 
         mock_post.assert_called_once()
         call_kwargs = mock_post.call_args
-        assert (
-            call_kwargs.kwargs.get("url") == "https://env.example.com/hook"
-            or call_kwargs[0][0] == "https://env.example.com/hook"
+        headers = call_kwargs.kwargs.get("headers") or {}
+        assert headers.get("Host") == "env.example.com", (
+            f"Host header should reflect the resolved env-var hostname; got {headers!r}"
         )
 
-    @patch("forgelm._http.requests.post")
+    @patch("forgelm._http.requests.Session.post")
     def test_notify_on_start_disabled(self, mock_post):
         config = _make_config(
             {
@@ -102,7 +111,7 @@ class TestWebhookNotifier:
         notifier.notify_start(run_name="test")
         mock_post.assert_not_called()
 
-    @patch("forgelm._http.requests.post")
+    @patch("forgelm._http.requests.Session.post")
     def test_timeout_handled_gracefully(self, mock_post):
         import requests as req
 
@@ -112,7 +121,7 @@ class TestWebhookNotifier:
         # Should not raise
         notifier.notify_start(run_name="test")
 
-    @patch("forgelm._http.requests.post")
+    @patch("forgelm._http.requests.Session.post")
     def test_connection_error_handled_gracefully(self, mock_post):
         import requests as req
 
@@ -122,7 +131,7 @@ class TestWebhookNotifier:
         # Should not raise
         notifier.notify_failure(run_name="test", reason="test error")
 
-    @patch("forgelm._http.requests.post")
+    @patch("forgelm._http.requests.Session.post")
     def test_payload_has_slack_attachments(self, mock_post):
         config = _make_config({"url": "https://example.com/hook"})
         notifier = WebhookNotifier(config)
@@ -134,7 +143,7 @@ class TestWebhookNotifier:
         assert len(payload["attachments"]) == 1
         assert "title" in payload["attachments"][0]
 
-    @patch("forgelm._http.requests.post")
+    @patch("forgelm._http.requests.Session.post")
     def test_http_5xx_logs_warning(self, mock_post, caplog):
         """Non-2xx HTTP responses must emit a WARNING and not raise."""
         import logging
@@ -153,7 +162,7 @@ class TestWebhookNotifier:
 
         assert any("503" in r.message or "HTTP" in r.message for r in caplog.records)
 
-    @patch("forgelm._http.requests.post")
+    @patch("forgelm._http.requests.Session.post")
     def test_http_4xx_logs_warning(self, mock_post, caplog):
         """HTTP 4xx response must emit a WARNING log and not raise."""
         import logging
@@ -208,7 +217,13 @@ class TestSafePostHttpDiscipline:
             safe_post(url, json={}, timeout=10.0)
 
     def test_ssrf_block_can_be_opted_out(self):
-        """allow_private=True bypasses the SSRF guard (operator opt-in)."""
+        """``allow_private=True`` bypasses the SSRF guard (operator opt-in).
+
+        The opt-in path deliberately keeps the legacy ``requests.post``
+        flow (no Session, no IP pinning) because internal DNS / split-
+        horizon resolution is the right model for an operator-blessed
+        in-cluster destination — see safe_post's ``allow_private`` branch.
+        """
         from forgelm import _http
 
         with patch.object(_http.requests, "post") as mock_post:
@@ -225,7 +240,7 @@ class TestSafePostHttpDiscipline:
         """allow_redirects=False is forwarded to requests.post."""
         from forgelm import _http
 
-        with patch.object(_http.requests, "post") as mock_post:
+        with patch.object(_http.requests.Session, "post") as mock_post:
             mock_post.return_value = MagicMock(ok=True, status_code=200)
             _http.safe_post("https://example.com/hook", json={}, timeout=10.0)
             kwargs = mock_post.call_args.kwargs
@@ -246,7 +261,7 @@ class TestSafePostHttpDiscipline:
         # back-compat path; the post is mocked, no real call is made.
         from forgelm import _http
 
-        with patch.object(_http.requests, "post") as mock_post:
+        with patch.object(_http.requests.Session, "post") as mock_post:
             mock_post.return_value = MagicMock(ok=True, status_code=200)
             _http.safe_post(
                 "http://example.com/hook",  # NOSONAR python:S5332
@@ -293,7 +308,7 @@ class TestSafePostHttpDiscipline:
         """Webhook passes min_timeout=1.0 to keep its historical floor."""
         from forgelm import _http
 
-        with patch.object(_http.requests, "post") as mock_post:
+        with patch.object(_http.requests.Session, "post") as mock_post:
             mock_post.return_value = MagicMock(ok=True, status_code=200)
             _http.safe_post(
                 "https://example.com/hook",
@@ -313,7 +328,7 @@ class TestSafePostHttpDiscipline:
 
         # NOSONAR test fixture, fragment-built (rule python:S2068 hard-coded credential false-positive)
         bearer_token = "sk-" + "supersecret123"  # noqa: S105
-        with patch.object(_http.requests, "post") as mock_post:
+        with patch.object(_http.requests.Session, "post") as mock_post:
             mock_post.side_effect = req.exceptions.ConnectionError(f"refused while sending Bearer {bearer_token}")
             with caplog.at_level(logging.WARNING, logger="forgelm._http"):
                 with pytest.raises(req.exceptions.ConnectionError):
@@ -345,7 +360,7 @@ class TestLifecycleVocabulary:
     don't silently break on a future refactor.
     """
 
-    @patch("forgelm._http.requests.post")
+    @patch("forgelm._http.requests.Session.post")
     def test_notify_reverted_payload(self, mock_post):
         """Auto-revert event must serialize as event=training.reverted with masked + truncated reason."""
         config = _make_config({"url": "https://example.com/hook"})
@@ -376,7 +391,7 @@ class TestLifecycleVocabulary:
         assert len(payload["reason"]) <= 2048 + len("… (truncated)")
         assert payload["reason"].endswith("… (truncated)")
 
-    @patch("forgelm._http.requests.post")
+    @patch("forgelm._http.requests.Session.post")
     def test_notify_reverted_distinct_from_failure(self, mock_post):
         """training.reverted must not collide with training.failure (dashboards rely on this split)."""
         config = _make_config({"url": "https://example.com/hook"})
@@ -392,7 +407,7 @@ class TestLifecycleVocabulary:
         # Color must signal "reverted" (warning orange), not "failed" (red).
         assert payload["attachments"][0]["color"] == "#ff9900"
 
-    @patch("forgelm._http.requests.post")
+    @patch("forgelm._http.requests.Session.post")
     def test_notify_awaiting_approval_payload(self, mock_post):
         """Approval gate must serialize as event=approval.required with model_path included."""
         config = _make_config({"url": "https://example.com/hook"})
@@ -414,7 +429,7 @@ class TestLifecycleVocabulary:
         assert payload["model_path"] == "/var/forgelm/runs/abc/final_model"
         assert "/var/forgelm/runs/abc/final_model" in payload["attachments"][0]["text"]
 
-    @patch("forgelm._http.requests.post")
+    @patch("forgelm._http.requests.Session.post")
     def test_notify_awaiting_approval_no_model_weights_in_payload(self, mock_post):
         """Security: approval payload must carry the staging path only, never weight bytes or tensor dumps."""
         config = _make_config({"url": "https://example.com/hook"})


### PR DESCRIPTION
Closes #14.

## Problem

`forgelm._http._is_private_destination()` pre-resolved the webhook / judge / synthetic hostname via `socket.getaddrinfo`, but `requests.post()` then performed its OWN DNS lookup at connect time. An attacker-controlled DNS server with TTL=0 could return a public IP on the first lookup (passing the guard) and a private IP on the second (when `requests` connected) — leaking the payload + bearer token to 127.0.0.1 / 169.254.169.254 (AWS IMDS) / RFC1918.

Issue body diagnosed this as the last remaining bypass after the existing default-secure layers (`allow_private_destinations: false` default + `allow_redirects=False`).

## Approach

1. New helper `_resolve_safe_destination(host) → (ip_or_none, reason_or_none)` resolves exactly once and returns either a public IP literal or a structured block reason.
2. `safe_post` / `safe_get` rebuild the outbound URL with the resolved IP literal so `requests` never re-resolves.
3. Original hostname is propagated via the `Host` header (mandatory for virtual-hosted endpoints — Slack / Teams / Discord — that route by hostname not IP) and via SNI through `requests_toolbelt.adapters.host_header_ssl.HostHeaderSSLAdapter`, mounted on a per-call `Session` for the `https://` scheme. Certificate validation continues to be performed against the original hostname.
4. `allow_private=True` callers keep the legacy `requests.post` flow so split-horizon DNS / in-cluster resolution still works for operator-blessed internal destinations.
5. IPv6 IP literals are bracketed per RFC 3986.

## Dependency decision

`requests-toolbelt>=1.0.0,<2.0.0` is added as a **hard dependency**, not an optional extra. Rationale:

- Tiny package (~30KB), same ecosystem as `requests` which is already required.
- The hardening must be **default-secure**: an opt-in extra would mean operators who forget the extra ship with the old TOCTOU bypass intact.
- Issue body left the call open ("new hard dep or optional extra — TBD"); I lean hard dep but happy to revisit if you'd prefer an extra.

## Threat model recap

| Factor | Value |
|---|---|
| Attacker capability | DNS server control for the configured webhook domain, or a downstream resolver they can poison |
| Existing mitigations (kept) | `allow_private_destinations: false` default, `allow_redirects=False`, scheme allowlist |
| Pre-fix bypass | DNS rebinding TOCTOU |
| Post-fix | DNS resolved once + URL pinned to public IP literal → second resolve impossible |

## Tests

**[tests/test_http_dns_rebinding.py](https://github.com/cemililik/ForgeLM/blob/fix/webhook-dns-rebinding-issue-14/tests/test_http_dns_rebinding.py)** — 13 new tests, all green:

- `TestResolveSafeDestination` (6) — public hostname, mixed-result blocking, DNS failure surfacing, empty host, public IP literal pass-through, private IP literal block.
- `TestDnsRebindingClosed` (5) — `getaddrinfo` called exactly once + URL pinned to public IP; `Host` header preserved with auth header; `HostHeaderSSLAdapter` mounted for `https://`; HTTP path does not mount the SSL adapter; `allow_private=True` bypasses pinning and uses the legacy `requests.post` flow.
- `TestIpv6PinningBuildsBracketedUrl` (1) — IPv6 literals bracketed per RFC 3986.
- `TestSafeGetPinning` (1) — `safe_get` mirrors `safe_post` for the same hardening contract.

**Updated existing tests** — `tests/test_webhook.py` + `tests/test_judge_functions.py` + `tests/test_synthetic.py`: 16 `@patch` targets switched from `forgelm._http.requests.post` to `forgelm._http.requests.Session.post` to follow the new dispatch path. Three URL-asserting tests (`test_url_env_resolution`, `test_custom_api_base`, `test_api_base_reaches_http_call`) reframed to assert on the `Host` header rather than the URL, because the URL now carries the resolved IP literal.

## Verification

- 11 / 11 self-review gauntlet guards green.
- `ruff format` + `ruff check`: clean (169 files).
- `pytest tests/test_http_dns_rebinding.py tests/test_webhook.py tests/test_judge_functions.py tests/test_synthetic.py tests/test_doctor.py`: 163 / 163 green.
- CHANGELOG entry under `[Unreleased]::Security` documenting the threat model, fix mechanism, and new dependency.

## Test plan

- [ ] CI cross-OS matrix (Linux / macOS / Windows × Python 3.10-13) — particularly want to confirm `HostHeaderSSLAdapter` behaves consistently across `requests` 2.31 → 2.32.
- [ ] Manual: real Slack webhook POST under default config — confirms SNI + cert validation still work end-to-end against `hooks.slack.com` (Fastly-fronted, cert is hostname-based).
- [ ] Manual: webhook config with `allow_private_destinations: true` against an in-cluster URL — confirms legacy path still works.
- [ ] Manual: webhook config pointing at a deliberate `127.0.0.1` literal — confirms guard still raises `HttpSafetyError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden HTTP webhook/judge/synthetic calls against DNS-rebinding SSRF by pinning requests to a single validated public IP while preserving virtual-host and TLS semantics, and document the change.

New Features:
- Add DNS-rebinding-safe destination resolution helper that validates hosts and returns a single public IP literal for outbound HTTP calls.
- Introduce pinned sessions for IP-literal HTTPS requests that preserve Host/SNI semantics via HostHeaderSSLAdapter.

Bug Fixes:
- Fix TOCTOU DNS-rebinding vulnerability in safe_post and safe_get by preventing a second, potentially malicious DNS resolution at connect time.

Enhancements:
- Extend safe_post and safe_get to rebuild URLs with resolved IPs, set Host headers, and preserve an operator opt-in path for internal/private destinations.
- Bracket IPv6 address literals in rebuilt URLs to comply with RFC 3986.

Build:
- Add requests-toolbelt as a hard runtime dependency to support HostHeaderSSLAdapter in the HTTP stack.

Documentation:
- Document the SSRF DNS-rebinding hardening, threat model, and new dependency in the Security section of the changelog.

Tests:
- Add regression test suite for the DNS-rebinding guard, including resolver behavior, URL pinning, Host/SNI handling, IPv6 pinning, and safe_get parity.
- Update existing webhook, judge, and synthetic tests to assert behavior via Host headers and the new session-based HTTP call path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Enhanced SSRF and webhook guard protection by pinning resolved IP addresses and preserving original hostname identity through header management, mitigating DNS-rebinding TOCTOU vulnerabilities.

* **Chores**
  * Added `requests-toolbelt` as a runtime dependency for secure host header and TLS support.

* **Tests**
  * Added comprehensive test coverage for DNS-rebinding hardening and SSRF guard validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cemililik/ForgeLM/pull/52)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->